### PR TITLE
fix for bug introduced in d20bb794

### DIFF
--- a/src/gencost/entity_ids.py
+++ b/src/gencost/entity_ids.py
@@ -141,7 +141,7 @@ def add_ba_code(
         raise ValueError(f"`input_df` is missing {missing}")
     ferc_match = (
         pd.read_parquet(PACKAGE_PATH / "utility_information.parquet.gzip")
-        .astype({"respondent_id": "Int64"})
+        .astype({"respondent_id": "Int64"})[["respondent_id", "utility_id_eia"]]
         .dropna()
         .drop_duplicates()
     )
@@ -155,7 +155,7 @@ def add_ba_code(
         raise AssertionError("utility_id_eia -> respondent_id not unique")
 
     out = input_df.merge(
-        ferc_match[["respondent_id", "utility_id_eia"]],
+        ferc_match,
         on="utility_id_eia",
         how="left",
         validate="m:1",


### PR DESCRIPTION
the change in d20bb794 introduced a bug that caused the entity id process to loose 120 utility_id -> respondent_id associations because of when dropna and drop_duplicates were applied