### PR TITLE
Pkg upgrades

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,14 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.12"
 dependencies = [
-    "bottleneck >= 1.3,< 1.3.8",
-    "numexpr >= 2.8, < 2.8.8",
+    "bottleneck >= 1.3,< 1.3.9",
+    "gcsfs",  # For reading from GCS, should get installed by pandas by sometimes doesn't
+    "numexpr >= 2.8, < 2.9.1",
     "numpy >= 1.18.5,<2",
     "networkx >= 3.0,< 3.3",
     "pandas[gcp] >= 1.4,< 2.0",
-    "pandera >= 0.12, < 0.18",
-    "platformdirs >=2.6,<4.1",
+    "pandera >= 0.12, < 0.19",
+    "platformdirs >=2.6,<4.3",
     "plotly>5.10,<5.19",
     "pyarrow>=7, <16",
     "polars[connectorx,fsspec]>=0.16,<0.21",


### PR DESCRIPTION
These are needed to align versions with etoolbox upstream and patio downstream. They will also help if not be necessary to switch to getting PUDL data from GCS so we can remove the need for both the pudl.sqlite and the goofy easy data pretend pudl table thing.


@mariacastillo21, if this is alright let me know and I can merge it in, you'll then want to update your working branche(s) and environments so that you can use the new PUDL system.